### PR TITLE
Fix project namespace and add global exception handlers

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -1,4 +1,4 @@
-﻿<Application x:Class="RC2CesiumPins.App"
+<Application x:Class="RSS_Image_Interoperability_Tool.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml">

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,8 +1,25 @@
-﻿using System.Windows;
+using System;
+using System.Threading.Tasks;
+using System.Windows;
 
-namespace RC2CesiumPins
+namespace RSS_Image_Interoperability_Tool
 {
     public partial class App : Application
     {
+        public App()
+        {
+            this.DispatcherUnhandledException += (s, e) =>
+            {
+                MessageBox.Show(e.Exception.ToString(), "Unhandled UI Exception");
+                e.Handled = true;
+            };
+            AppDomain.CurrentDomain.UnhandledException += (s, e) =>
+                MessageBox.Show(e.ExceptionObject.ToString()!, "Unhandled Domain Exception");
+            TaskScheduler.UnobservedTaskException += (s, e) =>
+            {
+                MessageBox.Show(e.Exception.ToString(), "Unhandled Task Exception");
+                e.SetObserved();
+            };
+        }
     }
 }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="RC2CesiumPins.MainWindow"
+<Window x:Class="RSS_Image_Interoperability_Tool.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="RSS Image Interoperability Tool"

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Win32;
+using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -15,7 +15,7 @@ using System.Windows.Media.Imaging;
 using MetadataExtractor;
 using MetadataExtractor.Formats.Exif;
 
-namespace RC2CesiumPins
+namespace RSS_Image_Interoperability_Tool
 {
     public partial class MainWindow : Window
     {


### PR DESCRIPTION
Updates the namespace in all relevant files to `RSS_Image_Interoperability_Tool` to match the project file names and ensure consistency.

Adds global exception handlers to `App.xaml.cs` for:
- `DispatcherUnhandledException`
- `AppDomain.CurrentDomain.UnhandledException`
- `TaskScheduler.UnobservedTaskException`

This improves the overall robustness of the application by catching and reporting unhandled exceptions that could otherwise cause it to crash silently.